### PR TITLE
Fix checks for escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ module.exports = function (options, callback) {
     if (
       !insideString && !insideComment
       && currentChar === "/"
-      && source[i - 1] !== "\\" // escaping
+      && !charIsEscaped(i)
     ) {
       // standard comments
       if (source[i + 1] === "*") {
@@ -104,7 +104,7 @@ module.exports = function (options, callback) {
       if (
         !insideSingleLineComment
         && currentChar === "*"
-        && source[i - 1] !== "\\" // escaping
+        && !charIsEscaped(i)
         && source[i + 1] === "/"
         && source[i - 1] !== "/" // don't end if it's /*/
       ) {
@@ -126,7 +126,7 @@ module.exports = function (options, callback) {
 
     // Register the beginning of a string
     if (!insideComment && !insideString && (currentChar === "\"" || currentChar === "'")) {
-      if (source[i - 1] === "\\") continue; // escaping
+      if (charIsEscaped(i)) continue; // escaping
 
       openingQuote = currentChar;
       insideString = true;
@@ -139,7 +139,7 @@ module.exports = function (options, callback) {
     if (insideString) {
       // Register the end of a string
       if (currentChar === openingQuote) {
-        if (source[i - 1] === "\\") continue; // escaping
+        if (charIsEscaped(i)) continue;
         insideString = false;
         continue;
       }
@@ -199,5 +199,11 @@ module.exports = function (options, callback) {
     if (onlyComments && !insideComment) return;
     matchCount++;
     callback(match, matchCount);
+  }
+
+  function charIsEscaped(index) {
+    var esc = false
+    while (source[--index] === "\\") esc = !esc
+    return esc
   }
 }

--- a/index.js
+++ b/index.js
@@ -202,8 +202,8 @@ module.exports = function (options, callback) {
   }
 
   function charIsEscaped(index) {
-    var esc = false
-    while (source[--index] === "\\") esc = !esc
-    return esc
+    var esc = false;
+    while (source[--index] === "\\") esc = !esc;
+    return esc;
   }
 }

--- a/test.js
+++ b/test.js
@@ -281,10 +281,30 @@ test("handles escaped double-quotes in double-quote strings", function(t) {
     source: 'abc "a\\"bc" foo cba',
     target: "c",
   }), [ 2, 16 ]);
+  t.deepEqual(styleSearchResults({
+    source: 'content: \\"\n',
+    target: "\n",
+    strings: 'only'
+  }), []);
+  t.deepEqual(styleSearchResults({
+    source: 'content: "\\"\n',
+    target: "\n",
+    strings: 'only'
+  }), [ 12 ]);
+  t.deepEqual(styleSearchResults({
+    source: 'content: "\\\\"\n',
+    target: "\n",
+    strings: 'only'
+  }), []);
+  t.deepEqual(styleSearchResults({
+    source: 'content: "\\\\\\"\n',
+    target: "\n",
+    strings: 'only'
+  }), [ 14 ]);
   t.end();
 });
 
-test("handles escaped double-quotes in single-quote strings", function(t) {
+test("handles escaped single-quotes in single-quote strings", function(t) {
   t.deepEqual(styleSearchResults({
     source: "abc 'ab\\'c'",
     target: "c",
@@ -293,6 +313,26 @@ test("handles escaped double-quotes in single-quote strings", function(t) {
     source: "abc 'a\\'bc' foo cba",
     target: "c",
   }), [ 2, 16 ]);
+  t.deepEqual(styleSearchResults({
+    source: "content: \\'\n",
+    target: "\n",
+    strings: 'only'
+  }), []);
+  t.deepEqual(styleSearchResults({
+    source: "content: '\\'\n",
+    target: "\n",
+    strings: 'only'
+  }), [ 12 ]);
+  t.deepEqual(styleSearchResults({
+    source: "content: '\\\\'\n",
+    target: "\n",
+    strings: 'only'
+  }), []);
+  t.deepEqual(styleSearchResults({
+    source: "content: '\\\\\\'\n",
+    target: "\n",
+    strings: 'only'
+  }), [ 14 ]);
   t.end();
 });
 


### PR DESCRIPTION
This updates the code for detecting escaped characters, because the correct checks do not account for edge cases where text has an even number of consecutive slashes. For example, the second quotation mark here is incorrectly treated as being escaped ```content: "\\\\"```.